### PR TITLE
Giant Boar Tweaks

### DIFF
--- a/1.2/Defs/ThingDefs_Animals/LotRD_GiantBoar.xml
+++ b/1.2/Defs/ThingDefs_Animals/LotRD_GiantBoar.xml
@@ -49,6 +49,14 @@
       <wildness>0.60</wildness>
       <trainability>Advanced</trainability>
       <manhunterOnTameFailChance>0.018</manhunterOnTameFailChance>
+      <wildBiomes>
+				<BorealForest>0.25</BorealForest>
+				<ColdBog>0.25</ColdBog>
+				<TemperateForest>0.25</TemperateForest>
+				<TemperateSwamp>0.25</TemperateSwamp>
+				<TropicalRainforest>0.25</TropicalRainforest>
+				<TropicalSwamp>0.25</TropicalSwamp>
+      </wildBiomes>
       <useMeatFrom>Pig</useMeatFrom>
       <useLeatherFrom>Pig</useLeatherFrom>
       <gestationPeriodDays>13</gestationPeriodDays>

--- a/Patches/GiantBoarBiomesPatch.xml
+++ b/Patches/GiantBoarBiomesPatch.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Lord of the Rims - Elves (Continued)</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd"> 
+					<xpath>/Defs/ThingDef[defName="LotRD_GiantBoarRace"]/race/wildBiomes</xpath>
+					<value>
+						<LotRE_MallornForest>0.25</LotRE_MallornForest>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Rimhammer - The End Times - Beastmen</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd"> 
+					<xpath>/Defs/ThingDef[defName="LotRD_GiantBoarRace"]/race/wildBiomes</xpath>
+					<value>
+						<RH_TET_Beastmen_OldGrowthForest>0.25</RH_TET_Beastmen_OldGrowthForest>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+	
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Alpha Biomes</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<operations>
+				<li Class="PatchOperationAdd"> 
+					<xpath>/Defs/ThingDef[defName="LotRD_GiantBoarRace"]/race/wildBiomes</xpath>
+					<value>
+						<AB_FeraliskInfestedJungle>0.02</AB_FeraliskInfestedJungle>
+						<AB_GelatinousSuperorganism>0.25</AB_GelatinousSuperorganism>
+						<AB_MycoticJungle>0.25</AB_MycoticJungle>
+					</value>
+				</li>
+			</operations>
+		</match>
+	</Operation>
+	
+		
+</Patch>
+


### PR DESCRIPTION
Adding the Giant Boar to Vanilla and modded Biomes. Commonality I put as half of the vanilla  wild boar, in the same biomes the vanilla boar spawns.